### PR TITLE
Fix producing of scan ResInfo failing because topic is empty

### DIFF
--- a/docker-compose-worker-1.yaml
+++ b/docker-compose-worker-1.yaml
@@ -235,3 +235,5 @@ services:
       - LOCAL_ADDRESS=${LOCAL_ADDRESS}
       # this is the default blocklist
       - BLOCKLIST_FILE_PATH=blocklist.conf
+    # needed to access db-1
+    network_mode: host

--- a/lib/consumer/helper.go
+++ b/lib/consumer/helper.go
@@ -43,6 +43,8 @@ func GetKafkaTopicFromScan(s scan.Scan) string {
 		return GetKafkaVPTopic(k.DEFAULT_EDSR_TOPIC, s.GetMetaInformation().VantagePoint)
 	case scan.DDR_DNSSEC_SCAN_TYPE:
 		return GetKafkaVPTopic(k.DEFAULT_DDR_DNSSEC_TOPIC, s.GetMetaInformation().VantagePoint)
+	case scan.RESINFO_SCAN_TYPE:
+		return GetKafkaVPTopic(k.DEFAULT_RESINFO_TOPIC, s.GetMetaInformation().VantagePoint)
 	default:
 		return ""
 	}


### PR DESCRIPTION
Fixes two problems with resinfo:
- The scans are not produced because the topic lookup was missing
- The resinfo scanner was not in the correct network so it could not communicate with kafka